### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Run Tests
 
+permissions:
+  contents: read
+  statuses: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/zealux/security/code-scanning/1](https://github.com/tobrien/zealux/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to define the least privileges required. Based on the workflow's steps:
- The `actions/checkout` action requires `contents: read` to fetch the repository code.
- The `codecov/codecov-action` may require `contents: read` and `statuses: write` to upload coverage reports and update commit statuses.

We will add the following `permissions` block at the root of the workflow:
```yaml
permissions:
  contents: read
  statuses: write
```

This ensures the workflow has only the necessary permissions to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
